### PR TITLE
feat: add data update when account change

### DIFF
--- a/src/contexts/StakeContext.tsx
+++ b/src/contexts/StakeContext.tsx
@@ -286,6 +286,7 @@ export const StakeContextProvider = (props: { children: React.ReactNode }) => {
             switchChain({ chainId: APP_ENV.ENABLE_TESTNETS ? zkSyncSepoliaTestnet.id : zkSync.id });
             refresh();
         }
+        refreshWithoutConnect();
     }, [address, chainId, accountStaus]);
 
     useEffect(() => {


### PR DESCRIPTION
I added refreshWithoutConnect() function when change account on context.
it's missed on useEffect. I think my removed it by mistake.